### PR TITLE
More descriptive error message for monadic bind usage. 

### DIFF
--- a/Text/Blaze/Internal.hs
+++ b/Text/Blaze/Internal.hs
@@ -148,7 +148,7 @@ instance Monad HtmlM where
     {-# INLINE return #-}
     (>>) = Append
     {-# INLINE (>>) #-}
-    h1 >>= f = h1 >> f (error "_|_")
+    h1 >>= f = h1 >> f (error "Invalid usage of monadic bind for Text.Blaze.Internal.HtmlM")
     {-# INLINE (>>=) #-}
 
 instance IsString (HtmlM a) where


### PR DESCRIPTION
I wrote something like () <- " some text " to avoid a compiler warning, and suddenly got a _|_ error message. It took me a long time to track it down, and I'm even familiar with the internal of blaze-html. I think it would be very confusing to most users.
