### PR TITLE
Functor instance

### DIFF
--- a/Text/Blaze/Internal.hs
+++ b/Text/Blaze/Internal.hs
@@ -125,9 +125,9 @@ data HtmlM a
     | forall b c. Append (HtmlM b) (HtmlM c)
     -- | Add an attribute to the inner HTML. Raw key, key, value, HTML to
     -- receive the attribute.
-    | AddAttribute StaticString StaticString ChoiceString (HtmlM a)
+    | forall b . AddAttribute StaticString StaticString ChoiceString (HtmlM b)
     -- | Add a custom attribute to the inner HTML.
-    | AddCustomAttribute ChoiceString ChoiceString ChoiceString (HtmlM a)
+    | forall b . AddCustomAttribute ChoiceString ChoiceString ChoiceString (HtmlM b)
     -- | Empty HTML.
     | Empty
     deriving (Typeable)
@@ -159,9 +159,9 @@ instance Functor HtmlM where
     fmap _ (Leaf a b c) = Leaf a b c
     fmap _ (Content a) = Content a
     fmap _ (Append a b) = Append a b
-    fmap f (AddAttribute a b c html) = AddAttribute a b c (fmap f html)
-    fmap f (AddCustomAttribute a b c html) =
-        AddCustomAttribute a b c (fmap f html)
+    fmap _ (AddAttribute a b c d) = AddAttribute a b c d
+    fmap _ (AddCustomAttribute a b c d) =
+        AddCustomAttribute a b c d
 
 instance IsString (HtmlM a) where
     fromString = Content . fromString


### PR DESCRIPTION
I have two versions of this, as two commits.

The first version requires no other changes, but needs to unpack and re-pack more of the Html type than I would like.

The second version adds more 'forall's to the Html constructors, which then means I don't have to fmap over child Html values. This doesn't seem to hurt anything, but it is a larger change.

The use case for this is being able to use the 'void' function from base.

I couldn't see a better way to fix issue #54.
