### PR TITLE
Increment upper bound on bytestring for GHC 7.6

### DIFF
--- a/blaze-html.cabal
+++ b/blaze-html.cabal
@@ -51,7 +51,7 @@ Library
     base          >= 4     && < 5,
     blaze-builder >= 0.2   && < 0.4,
     blaze-markup  >= 0.5.1 && < 0.6,
-    bytestring    >= 0.9   && < 0.10,
+    bytestring    >= 0.9   && < 0.11,
     text          >= 0.10  && < 0.12
 
 Test-suite blaze-html-tests
@@ -76,7 +76,7 @@ Test-suite blaze-html-tests
     base          >= 4     && < 5,
     blaze-builder >= 0.2   && < 0.4,
     blaze-markup  >= 0.5.1 && < 0.6,
-    bytestring    >= 0.9   && < 0.10,
+    bytestring    >= 0.9   && < 0.11,
     text          >= 0.10  && < 0.12
 
 Source-repository head


### PR DESCRIPTION
Increment the upper bound on the bytestring version.
