### PR TITLE
Bump text upper version bounds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,10 @@ local
 *.hi
 *.swp
 
+.cabal-sandbox/
+cabal.sandbox.config
+cabal.config
+
 TestSuite.tix
 .hpc
 hpc

--- a/blaze-html.cabal
+++ b/blaze-html.cabal
@@ -55,7 +55,7 @@ Library
     blaze-builder >= 0.2  && < 0.4,
     blaze-markup  >= 0.6  && < 0.7,
     bytestring    >= 0.9  && < 0.11,
-    text          >= 0.10 && < 1.2
+    text          >= 0.10 && < 1.3
 
 Test-suite blaze-html-tests
   Type:           exitcode-stdio-1.0
@@ -80,7 +80,7 @@ Test-suite blaze-html-tests
     blaze-builder >= 0.2   && < 0.4,
     blaze-markup  >= 0.6   && < 0.7,
     bytestring    >= 0.9   && < 0.11,
-    text          >= 0.10  && < 1.2
+    text          >= 0.10  && < 1.3
 
 Source-repository head
   Type:     git


### PR DESCRIPTION
Allow `blaze-html` to use `text-1.2.0.0`.
