### PR TITLE
Added 'viewport' to attribute list.

### DIFF
--- a/src/Util/GenerateHtmlCombinators.hs
+++ b/src/Util/GenerateHtmlCombinators.hs
@@ -449,7 +449,7 @@ html5 = HtmlVariant
         , "scoped", "seamless", "selected", "shape", "size", "sizes", "span"
         , "spellcheck", "src", "srcdoc", "start", "step", "style", "subject"
         , "summary", "tabindex", "target", "title", "type", "usemap", "value"
-        , "width", "wrap", "xmlns"
+        , "viewport", "width", "wrap", "xmlns"
         ]
     , selfClosing = False
     }


### PR DESCRIPTION
Viewport is used in meta tags for ensuring resolution on certain devices.

example:
    <meta name="viewport" content="width=device-width, initial-scale=1.0">