### PR TITLE
Add itemscope and itemtype HTML5 attributes

### DIFF
--- a/src/Util/GenerateHtmlCombinators.hs
+++ b/src/Util/GenerateHtmlCombinators.hs
@@ -428,6 +428,7 @@ html5 = HtmlVariant
         , "form", "formaction", "formenctype", "formmethod", "formnovalidate"
         , "formtarget", "headers", "height", "hidden", "high", "href"
         , "hreflang", "http-equiv", "icon", "id", "ismap", "item", "itemprop"
+        , "itemscope", "itemtype"
         , "keytype", "label", "lang", "list", "loop", "low", "manifest", "max"
         , "maxlength", "media", "method", "min", "multiple", "name"
         , "novalidate", "onbeforeonload", "onbeforeprint", "onblur", "oncanplay"


### PR DESCRIPTION
These tags are part of the HTML5 spec and important for Microdata.

See http://schema.org/docs/gs.html#microdata_itemscope_itemtype