### PR TITLE
Added CSS style and value modules to work with blaze-markup css branch

### DIFF
--- a/src/Text/Blaze/Css21/Style.hs
+++ b/src/Text/Blaze/Css21/Style.hs
@@ -1,0 +1,454 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Text.Blaze.Css21.Style
+    ( backgroundAttachment
+    , backgroundColor
+    , backgroundImage
+    , backgroundPosition
+    , backgroundRepeat
+    , background
+    , borderCollapse
+    , borderColor
+    , borderSpacing
+    , borderStyle
+    , borderTop
+    , borderRight
+    , borderBottom
+    , borderLeft
+    , borderTopColor
+    , borderRightColor
+    , borderBottomColor
+    , borderLeftColor
+    , borderTopStyle
+    , borderRightStyle
+    , borderBottomStyle
+    , borderLeftStyle
+    , borderTopWidth
+    , borderRightWidth
+    , borderBottomWidth
+    , borderLeftWidth
+    , borderWidth
+    , border
+    , captionSide
+    , clear
+    , clip
+    , color
+    , cursor
+    , direction
+    , display
+    , emptyCells
+    , float
+    , fontFamily
+    , fontSize
+    , fontStyle
+    , fontVariant
+    , fontWeight
+    , height
+    , left
+    , letterSpacing
+    , lineHeight
+    , listStyleImage
+    , listStylePosition
+    , listStyleType
+    , marginLeft
+    , marginRight
+    , marginTop
+    , marginBottom
+    , margin
+    , maxHeight
+    , maxWidth
+    , minHeight
+    , minWidth
+    , orphans
+    , outlineColor
+    , outlineStyle
+    , outlineWidth
+    , outline
+    , overflow
+    , paddingTop
+    , paddingRight
+    , paddingBottom
+    , paddingLeft
+    , padding
+    , pageBreakAfter
+    , pageBreakBefore
+    , pageBreakInside
+    , position
+    , right
+    , tableLayout
+    , textAlign
+    , textDecoration
+    , textIndent
+    , textTransform
+    , top
+    , unicodeBiDi
+    , verticalAlign
+    , visibility
+    , whitespace
+    , width
+    , widows
+    , wordSpacing
+    , zIndex
+    )
+where
+
+import qualified    Text.Blaze.Internal as B
+import              Text.Blaze.Css21.Value
+
+
+backgroundAttachment :: Value -> B.Attribute
+backgroundAttachment = B.cssStyle "background-attachment" "background-attachment: " . B.stringValue . toString
+
+backgroundColor :: Value -> B.Attribute
+backgroundColor = B.cssStyle "background-color" "background-color: " . B.stringValue . toString
+
+backgroundImage :: Value -> B.Attribute
+backgroundImage = B.cssStyle "background-image" "background-image: " . B.stringValue . toString
+
+backgroundPosition :: Value -> B.Attribute
+backgroundPosition = B.cssStyle "background-position" "background-position: " . B.stringValue . toString
+
+backgroundRepeat :: Value -> B.Attribute
+backgroundRepeat = B.cssStyle "background-repeat" "background-repeat: " . B.stringValue . toString
+
+background :: Value -> B.Attribute
+background = B.cssStyle "background" "background: " . B.stringValue . toString
+
+borderCollapse :: Value -> B.Attribute
+borderCollapse = B.cssStyle "border-collapse" "border-collapse: " . B.stringValue . toString
+
+borderColor :: Value -> B.Attribute
+borderColor = B.cssStyle "border-color" "border-color: " . B.stringValue . toString
+
+borderSpacing :: Value -> B.Attribute
+borderSpacing = B.cssStyle "border-spacing" "border-spacing: " . B.stringValue . toString
+
+borderStyle :: Value -> B.Attribute
+borderStyle = B.cssStyle "border-style" "border-style: " . B.stringValue . toString
+
+borderTop :: Value -> B.Attribute
+borderTop = B.cssStyle "border-top" "border-top: " . B.stringValue . toString
+
+borderRight :: Value -> B.Attribute
+borderRight = B.cssStyle "border-right" "border-right: " . B.stringValue . toString
+
+borderBottom :: Value -> B.Attribute
+borderBottom = B.cssStyle "border-bottom" "border-bottom: " . B.stringValue . toString
+
+borderLeft :: Value -> B.Attribute
+borderLeft = B.cssStyle "border-left" "border-left: " . B.stringValue . toString
+
+borderTopColor :: Value -> B.Attribute
+borderTopColor = B.cssStyle "border-top-color" "border-top-color: " . B.stringValue . toString
+
+borderRightColor :: Value -> B.Attribute
+borderRightColor = B.cssStyle "border-right-color" "border-right-color: " . B.stringValue . toString
+
+borderBottomColor :: Value -> B.Attribute
+borderBottomColor = B.cssStyle "border-bottom-color" "border-bottom-color: " . B.stringValue . toString
+
+borderLeftColor :: Value -> B.Attribute
+borderLeftColor = B.cssStyle "border-left-color" "border-left-color: " . B.stringValue . toString
+
+borderTopStyle :: Value -> B.Attribute
+borderTopStyle = B.cssStyle "border-top-style" "border-top-style: " . B.stringValue . toString
+
+borderRightStyle :: Value -> B.Attribute
+borderRightStyle = B.cssStyle "border-right-style" "border-right-style: " . B.stringValue . toString
+
+borderBottomStyle :: Value -> B.Attribute
+borderBottomStyle = B.cssStyle "border-bottom-style" "border-bottom-style: " . B.stringValue . toString
+
+borderLeftStyle :: Value -> B.Attribute
+borderLeftStyle = B.cssStyle "border-left-style" "border-left-style: " . B.stringValue . toString
+
+borderTopWidth :: Value -> B.Attribute
+borderTopWidth = B.cssStyle "border-top-width" "border-top-width: " . B.stringValue . toString
+
+borderRightWidth :: Value -> B.Attribute
+borderRightWidth = B.cssStyle "border-right-width" "border-right-width: " . B.stringValue . toString
+
+borderBottomWidth :: Value -> B.Attribute
+borderBottomWidth = B.cssStyle "border-bottom-width" "border-bottom-width: " . B.stringValue . toString
+
+borderLeftWidth :: Value -> B.Attribute
+borderLeftWidth = B.cssStyle "border-left-width" "border-left-width: " . B.stringValue . toString
+
+borderWidth :: Value -> B.Attribute
+borderWidth = B.cssStyle "border-width" "border-width: " . B.stringValue . toString
+
+border :: Value -> B.Attribute
+border = B.cssStyle "border" "border: " . B.stringValue . toString
+
+captionSide :: Value -> B.Attribute
+captionSide = B.cssStyle "caption-side" "caption-side: " . B.stringValue . toString
+
+clear :: Value -> B.Attribute
+clear = B.cssStyle "clear" "clear: " . B.stringValue . toString
+
+clip :: Value -> B.Attribute
+clip = B.cssStyle "clip" "clip: " . B.stringValue . toString
+
+color :: Value -> B.Attribute
+color = B.cssStyle "color" "color: " . B.stringValue . toString
+
+cursor :: Value -> B.Attribute
+cursor = B.cssStyle "cursor" "cursor: " . B.stringValue . toString
+
+direction :: Value -> B.Attribute
+direction = B.cssStyle "direction" "direction: " . B.stringValue . toString
+
+display :: Value -> B.Attribute
+display = B.cssStyle "display" "display: " . B.stringValue . toString
+
+emptyCells :: Value -> B.Attribute
+emptyCells = B.cssStyle "empty-cells" "empty-cells: " . B.stringValue . toString
+
+float :: Value -> B.Attribute
+float = B.cssStyle "float" "float: " . B.stringValue . toString
+
+fontFamily :: Value -> B.Attribute
+fontFamily = B.cssStyle "font-family" "font-family: " . B.stringValue . toString
+
+fontSize :: Value -> B.Attribute
+fontSize = B.cssStyle "font-size" "font-size: " . B.stringValue . toString
+
+fontStyle :: Value -> B.Attribute
+fontStyle = B.cssStyle "font-style" "font-style: " . B.stringValue . toString
+
+fontVariant :: Value -> B.Attribute
+fontVariant = B.cssStyle "font-variant" "font-variant: " . B.stringValue . toString
+
+fontWeight :: Value -> B.Attribute
+fontWeight = B.cssStyle "font-weight" "font-weight: " . B.stringValue . toString
+
+height :: Value -> B.Attribute
+height = B.cssStyle "height" "height: " . B.stringValue . toString
+
+left :: Value -> B.Attribute
+left = B.cssStyle "left" "left: " . B.stringValue . toString
+
+letterSpacing :: Value -> B.Attribute
+letterSpacing = B.cssStyle "letter-spacing" "letter-spacing: " . B.stringValue . toString
+
+lineHeight :: Value -> B.Attribute
+lineHeight = B.cssStyle "line-height" "line-height: " . B.stringValue . toString
+
+listStyleImage :: Value -> B.Attribute
+listStyleImage = B.cssStyle "list-style-image" "list-style-image: " . B.stringValue . toString
+
+listStylePosition :: Value -> B.Attribute
+listStylePosition = B.cssStyle "list-style-position" "list-style-position: " . B.stringValue . toString
+
+listStyleType :: Value -> B.Attribute
+listStyleType = B.cssStyle "list-style-type" "list-style-type: " . B.stringValue . toString
+
+marginLeft :: Value -> B.Attribute
+marginLeft = B.cssStyle "margin-left" "margin-left: " . B.stringValue . toString
+
+marginRight :: Value -> B.Attribute
+marginRight = B.cssStyle "margin-right" "margin-right: " . B.stringValue . toString
+
+marginTop :: Value -> B.Attribute
+marginTop = B.cssStyle "margin-top" "margin-top: " . B.stringValue . toString
+
+marginBottom :: Value -> B.Attribute
+marginBottom = B.cssStyle "margin-bottom" "margin-bottom: " . B.stringValue . toString
+
+margin :: Value -> B.Attribute
+margin = B.cssStyle "margin" "margin: " . B.stringValue . toString
+
+maxHeight :: Value -> B.Attribute
+maxHeight = B.cssStyle "max-height" "max-height: " . B.stringValue . toString
+
+maxWidth :: Value -> B.Attribute
+maxWidth = B.cssStyle "max-width" "max-width: " . B.stringValue . toString
+
+minHeight :: Value -> B.Attribute
+minHeight = B.cssStyle "min-height" "min-height: " . B.stringValue . toString
+
+minWidth :: Value -> B.Attribute
+minWidth = B.cssStyle "min-width" "min-width: " . B.stringValue . toString
+
+orphans :: Value -> B.Attribute
+orphans = B.cssStyle "orphans" "orphans: " . B.stringValue . toString
+
+outlineColor :: Value -> B.Attribute
+outlineColor = B.cssStyle "outline-color" "outline-color: " . B.stringValue . toString
+
+outlineStyle :: Value -> B.Attribute
+outlineStyle = B.cssStyle "outline-style" "outline-style: " . B.stringValue . toString
+
+outlineWidth :: Value -> B.Attribute
+outlineWidth = B.cssStyle "outline-width" "outline-width: " . B.stringValue . toString
+
+outline :: Value -> B.Attribute
+outline = B.cssStyle "outline" "outline: " . B.stringValue . toString
+
+overflow :: Value -> B.Attribute
+overflow = B.cssStyle "overflow" "overflow: " . B.stringValue . toString
+
+paddingTop :: Value -> B.Attribute
+paddingTop = B.cssStyle "padding-top" "padding-top: " . B.stringValue . toString
+
+paddingRight :: Value -> B.Attribute
+paddingRight = B.cssStyle "padding-right" "padding-right: " . B.stringValue . toString
+
+paddingBottom :: Value -> B.Attribute
+paddingBottom = B.cssStyle "padding-bottom" "padding-bottom: " . B.stringValue . toString
+
+paddingLeft :: Value -> B.Attribute
+paddingLeft = B.cssStyle "padding-left" "padding-left: " . B.stringValue . toString
+
+padding :: Value -> B.Attribute
+padding = B.cssStyle "padding" "padding: " . B.stringValue . toString
+
+pageBreakAfter :: Value -> B.Attribute
+pageBreakAfter = B.cssStyle "page-break-after" "page-break-after: " . B.stringValue . toString
+
+pageBreakBefore :: Value -> B.Attribute
+pageBreakBefore = B.cssStyle "page-break-before" "page-break-before: " . B.stringValue . toString
+
+pageBreakInside :: Value -> B.Attribute
+pageBreakInside = B.cssStyle "page-break-inside" "page-break-inside: " . B.stringValue . toString
+
+position :: Value -> B.Attribute
+position = B.cssStyle "position" "position: " . B.stringValue . toString
+
+right :: Value -> B.Attribute
+right = B.cssStyle "right" "right: " . B.stringValue . toString
+
+tableLayout :: Value -> B.Attribute
+tableLayout = B.cssStyle "table-layout" "table-layout: " . B.stringValue . toString
+
+textAlign :: Value -> B.Attribute
+textAlign = B.cssStyle "text-align" "text-align: " . B.stringValue . toString
+
+textDecoration :: Value -> B.Attribute
+textDecoration = B.cssStyle "text-decoration" "text-decoration: " . B.stringValue . toString
+
+textIndent :: Value -> B.Attribute
+textIndent = B.cssStyle "text-indent" "text-indent: " . B.stringValue . toString
+
+textTransform :: Value -> B.Attribute
+textTransform = B.cssStyle "text-transform" "text-transform: " . B.stringValue . toString
+
+top :: Value -> B.Attribute
+top = B.cssStyle "top" "top: " . B.stringValue . toString
+
+unicodeBiDi :: Value -> B.Attribute
+unicodeBiDi = B.cssStyle "unicode-bi-di" "unicode-bi-di: " . B.stringValue . toString
+
+verticalAlign :: Value -> B.Attribute
+verticalAlign = B.cssStyle "vertical-align" "vertical-align: " . B.stringValue . toString
+
+visibility :: Value -> B.Attribute
+visibility = B.cssStyle "visibility" "visibility: " . B.stringValue . toString
+
+whitespace :: Value -> B.Attribute
+whitespace = B.cssStyle "whitespace" "whitespace: " . B.stringValue . toString
+
+width :: Value -> B.Attribute
+width = B.cssStyle "width" "width: " . B.stringValue . toString
+
+widows :: Value -> B.Attribute
+widows = B.cssStyle "widows" "widows: " . B.stringValue . toString
+
+wordSpacing :: Value -> B.Attribute
+wordSpacing = B.cssStyle "word-spacing" "word-spacing: " . B.stringValue . toString
+
+zIndex :: Value -> B.Attribute
+zIndex = B.cssStyle "z-index" "z-index: " . B.stringValue . toString
+
+
+
+{-# INLINE backgroundAttachment #-}
+{-# INLINE backgroundColor #-}
+{-# INLINE backgroundImage #-}
+{-# INLINE backgroundPosition #-}
+{-# INLINE backgroundRepeat #-}
+{-# INLINE background #-}
+{-# INLINE borderCollapse #-}
+{-# INLINE borderColor #-}
+{-# INLINE borderSpacing #-}
+{-# INLINE borderStyle #-}
+{-# INLINE borderTop #-}
+{-# INLINE borderRight #-}
+{-# INLINE borderBottom #-}
+{-# INLINE borderLeft #-}
+{-# INLINE borderTopColor #-}
+{-# INLINE borderRightColor #-}
+{-# INLINE borderBottomColor #-}
+{-# INLINE borderLeftColor #-}
+{-# INLINE borderTopStyle #-}
+{-# INLINE borderRightStyle #-}
+{-# INLINE borderBottomStyle #-}
+{-# INLINE borderLeftStyle #-}
+{-# INLINE borderTopWidth #-}
+{-# INLINE borderRightWidth #-}
+{-# INLINE borderBottomWidth #-}
+{-# INLINE borderLeftWidth #-}
+{-# INLINE borderWidth #-}
+{-# INLINE border #-}
+{-# INLINE captionSide #-}
+{-# INLINE clear #-}
+{-# INLINE clip #-}
+{-# INLINE color #-}
+{-# INLINE cursor #-}
+{-# INLINE direction #-}
+{-# INLINE display #-}
+{-# INLINE emptyCells #-}
+{-# INLINE float #-}
+{-# INLINE fontFamily #-}
+{-# INLINE fontSize #-}
+{-# INLINE fontStyle #-}
+{-# INLINE fontVariant #-}
+{-# INLINE fontWeight #-}
+{-# INLINE height #-}
+{-# INLINE left #-}
+{-# INLINE letterSpacing #-}
+{-# INLINE lineHeight #-}
+{-# INLINE listStyleImage #-}
+{-# INLINE listStylePosition #-}
+{-# INLINE listStyleType #-}
+{-# INLINE marginLeft #-}
+{-# INLINE marginRight #-}
+{-# INLINE marginTop #-}
+{-# INLINE marginBottom #-}
+{-# INLINE margin #-}
+{-# INLINE maxHeight #-}
+{-# INLINE maxWidth #-}
+{-# INLINE minHeight #-}
+{-# INLINE minWidth #-}
+{-# INLINE orphans #-}
+{-# INLINE outlineColor #-}
+{-# INLINE outlineStyle #-}
+{-# INLINE outlineWidth #-}
+{-# INLINE outline #-}
+{-# INLINE overflow #-}
+{-# INLINE paddingTop #-}
+{-# INLINE paddingRight #-}
+{-# INLINE paddingBottom #-}
+{-# INLINE paddingLeft #-}
+{-# INLINE padding #-}
+{-# INLINE pageBreakAfter #-}
+{-# INLINE pageBreakBefore #-}
+{-# INLINE pageBreakInside #-}
+{-# INLINE position #-}
+{-# INLINE right #-}
+{-# INLINE tableLayout #-}
+{-# INLINE textAlign #-}
+{-# INLINE textDecoration #-}
+{-# INLINE textIndent #-}
+{-# INLINE textTransform #-}
+{-# INLINE top #-}
+{-# INLINE unicodeBiDi #-}
+{-# INLINE verticalAlign #-}
+{-# INLINE visibility #-}
+{-# INLINE whitespace #-}
+{-# INLINE width #-}
+{-# INLINE widows #-}
+{-# INLINE wordSpacing #-}
+{-# INLINE zIndex #-}
+
+

--- a/src/Text/Blaze/Css21/Value.hs
+++ b/src/Text/Blaze/Css21/Value.hs
@@ -1,0 +1,397 @@
+
+
+module Text.Blaze.Css21.Value
+    ( Value(..)
+    , toString
+    , showCss
+    )
+where
+
+
+import qualified    Prelude             as Prelude
+import              Prelude             hiding ( Left , Right )
+import              Data.Ratio          ( denominator , numerator )
+import              Data.Word           ( Word8 )
+import              Data.List           ( intersperse )
+import              Numeric             ( showInt , showHex )
+
+type Number = Rational
+
+showNumber :: Number -> ShowS
+showNumber a
+    | denominator a == 1 = shows $ numerator a
+    | otherwise          = shows $ fromRational a
+
+showCss :: Value -> ShowS
+showCss = (++) . to_string
+
+toString :: Value -> String
+toString = to_string
+
+data Value
+    = Values [Value]
+    | Absolute
+    | Always
+    | Aqua
+    | Armenian
+    | Auto
+    | Avoid 
+    | Baseline
+    | BiDiOverride
+    | Black
+    | Blink
+    | Block
+    | Blue
+    | Bold
+    | Bolder
+    | Both
+    | Bottom
+    | Capitalize
+    | Caption
+    | Center
+    | Circle
+    | Cm Number
+    | Collapse
+    | Crosshair
+    | Cursive
+    | Dashed
+    | Decimal
+    | DecimalLeadingZero
+    | Default
+    | Disc
+    | Dotted
+    | Double
+    | EResize
+    | Em Number
+    | Embed
+    | Ex Number
+    | FamilyName Prelude.String
+    | Fantasy
+    | Fixed
+    | Fuchsia
+    | Georgian
+    | Gray
+    | Green
+    | Groove
+    | Help
+    | Hidden
+    | Hide
+    | Icon
+    | In Number
+    | Inherit
+    | Inline
+    | InlineBlock
+    | InlineTable
+    | Inset
+    | Inside
+    | Integer Prelude.Integer
+    | Invert
+    | Italic
+    | Justify
+    | Large
+    | Larger
+    | Left
+    | Left_
+    | Lighter
+    | Lime
+    | LineThrough
+    | ListItem
+    | LowerAlpha
+    | LowerGreek
+    | LowerLatin
+    | LowerRoman
+    | Lowercase
+    | Ltr
+    | Maroon
+    | Medium
+    | Menu
+    | MessageBox
+    | Middle
+    | Mm Number
+    | Monospace
+    | Move
+    | NResize
+    | Navy
+    | NeResize
+    | NoRepeat
+    | None
+    | Normal
+    | Nowrap
+    | Number Rational
+    | NwResize
+    | Oblique
+    | Olive
+    | Orange
+    | Outset
+    | Outside
+    | Overline
+    | Pc Number
+    | Percent Number
+    | Percent100
+    | Pointer
+    | Pre
+    | PreLine
+    | PreWrap
+    | Progress
+    | Pt Number
+    | Purple
+    | Px Number
+    | RGB Word8 Word8 Word8
+    | RGB24 Word8 Word8 Word8
+    | RGBPercent Rational Rational Rational
+    | Rect Value Value Value Value
+    | Red
+    | Relative
+    | Repeat
+    | RepeatX
+    | RepeatY
+    | Ridge
+    | Right
+    | Right_
+    | Rtl
+    | SResize
+    | SansSerif
+    | Scroll
+    | SeResize
+    | Separate
+    | Serif
+    | Show
+    | Silver
+    | Small
+    | SmallCaps
+    | SmallCaption
+    | Smaller
+    | Solid
+    | Square
+    | Static
+    | StatusBar
+    | Sub
+    | Super
+    | SwResize
+    | Table
+    | TableCaption
+    | TableCell
+    | TableColumn
+    | TableColumnGroup
+    | TableFooterGroup
+    | TableHeaderGroup
+    | TableRow
+    | TableRowGroup
+    | Teal
+    | Text
+    | TextBottom
+    | TextTop
+    | Thick
+    | Thin
+    | Top
+    | Transparent
+    | URI Prelude.String
+    | Underline
+    | UpperAlpha 
+    | UpperLatin
+    | UpperRoman
+    | Uppercase
+    | Visible
+    | WResize
+    | Wait
+    | Weight100
+    | Weight200
+    | Weight300
+    | Weight400
+    | Weight500
+    | Weight600
+    | Weight700
+    | Weight800
+    | Weight900 
+    | White
+    | XLarge
+    | XSmall
+    | XXLarge
+    | XXSmall
+    | Yellow
+    | Zero
+    deriving ( Show , Read )
+
+to_string :: Value -> String
+to_string (Values as)            = concat $ intersperse " " $ map to_string as
+to_string Absolute               = "absolute"
+to_string Always                 = "always"
+to_string Aqua                   = "aqua"
+to_string Armenian               = "armenian"
+to_string Auto                   = "auto"
+to_string Avoid                  = "avoid"
+to_string Baseline               = "baseline"
+to_string BiDiOverride           = "bi-di-override"
+to_string Black                  = "black"
+to_string Blink                  = "blink"
+to_string Block                  = "block"
+to_string Blue                   = "blue"
+to_string Bold                   = "bold"
+to_string Bolder                 = "bolder"
+to_string Both                   = "both"
+to_string Bottom                 = "bottom"
+to_string Capitalize             = "capitalize"
+to_string Caption                = "caption"
+to_string Center                 = "center"
+to_string Circle                 = "circle"
+to_string (Cm a)                 = showNumber a "cm"
+to_string Collapse               = "collapse"
+to_string Crosshair              = "crosshair"
+to_string Cursive                = "cursive"
+to_string Dashed                 = "dashed"
+to_string Decimal                = "decimal"
+to_string DecimalLeadingZero     = "decimal-leading-zero"
+to_string Default                = "default"
+to_string Disc                   = "disc"
+to_string Dotted                 = "dotted"
+to_string Double                 = "double"
+to_string EResize                = "e-resize"
+to_string (Em a)                 = showNumber a "em"
+to_string Embed                  = "embed"
+to_string (Ex a)                 = showNumber a "ex"
+to_string (FamilyName a)         = a
+to_string Fantasy                = "fantasy"
+to_string Fixed                  = "fixed"
+to_string Fuchsia                = "fuchsia"
+to_string Georgian               = "georgian"
+to_string Gray                   = "gray"
+to_string Green                  = "green"
+to_string Groove                 = "groove"
+to_string Help                   = "help"
+to_string Hidden                 = "hidden"
+to_string Hide                   = "hide"
+to_string Icon                   = "icon"
+to_string (In a)                 = showNumber a "in"
+to_string Inherit                = "inherit"
+to_string Inline                 = "inline"
+to_string InlineBlock            = "inline-block"
+to_string InlineTable            = "inline-table"
+to_string Inset                  = "inset"
+to_string Inside                 = "inside"
+to_string (Integer a)            = show a
+to_string Invert                 = "invert"
+to_string Italic                 = "italic"
+to_string Justify                = "justify"
+to_string Large                  = "large"
+to_string Larger                 = "larger"
+to_string Left                   = "left"
+to_string Left_                  = "left"
+to_string Lighter                = "lighter"
+to_string Lime                   = "lime"
+to_string LineThrough            = "line-through"
+to_string ListItem               = "list-item"
+to_string LowerAlpha             = "lower-alpha"
+to_string LowerGreek             = "lower-greek"
+to_string LowerLatin             = "lower-latin"
+to_string LowerRoman             = "lower-roman"
+to_string Lowercase              = "lowercase"
+to_string Ltr                    = "ltr"
+to_string Maroon                 = "maroon"
+to_string Medium                 = "medium"
+to_string Menu                   = "menu"
+to_string MessageBox             = "message-box"
+to_string Middle                 = "middle"
+to_string (Mm a)                 = showNumber a "mm"
+to_string Monospace              = "monospace"
+to_string Move                   = "move"
+to_string NResize                = "n-resize"
+to_string Navy                   = "navy"
+to_string NeResize               = "ne-resize"
+to_string NoRepeat               = "no-repeat"
+to_string None                   = "none"
+to_string Normal                 = "normal"
+to_string Nowrap                 = "nowrap"
+to_string (Number a)             = show $ fromRational a
+to_string NwResize               = "nw-resize"
+to_string Oblique                = "oblique"
+to_string Olive                  = "olive"
+to_string Orange                 = "orange"
+to_string Outset                 = "outset"
+to_string Outside                = "outside"
+to_string Overline               = "overline"
+to_string (Pc a)                 = showNumber a "pc"
+to_string (Percent a)            = showNumber a "%"
+to_string Percent100             = "100%"
+to_string Pointer                = "pointer"
+to_string Pre                    = "pre"
+to_string PreLine                = "pre-line"
+to_string PreWrap                = "pre-wrap"
+to_string Progress               = "progress"
+to_string (Pt a)                 = showNumber a "pt"
+to_string Purple                 = "purple"
+to_string (Px a)                 = showNumber a "px"
+to_string (RGB r g b)            = "rgb(" ++ showInt r "," ++ showInt g "," ++ showInt b ")"
+to_string (RGB24 r g b)          = "rgb(#" ++ showHex r ",#" ++ showHex g ",#" ++ showHex b ")"
+to_string (RGBPercent r g b)     = "rgb(" ++ showNumber r "%," ++ showNumber g "%," ++ showNumber b "%)"
+to_string (Rect t r b l)         = "rect(" ++ showCss t "," ++ showCss r "," ++ showCss b "," ++ showCss l ")"
+to_string Red                    = "red"
+to_string Relative               = "relative"
+to_string Repeat                 = "repeat"
+to_string RepeatX                = "repeat-x"
+to_string RepeatY                = "repeat-y"
+to_string Ridge                  = "ridge"
+to_string Right                  = "right"
+to_string Right_                 = "right"
+to_string Rtl                    = "rtl"
+to_string SResize                = "s-resize"
+to_string SansSerif              = "sans-serif"
+to_string Scroll                 = "scroll"
+to_string SeResize               = "se-resize"
+to_string Separate               = "separate"
+to_string Serif                  = "serif"
+to_string Show                   = "show"
+to_string Silver                 = "silver"
+to_string Small                  = "small"
+to_string SmallCaps              = "small-caps"
+to_string SmallCaption           = "small-caption"
+to_string Smaller                = "smaller"
+to_string Solid                  = "solid"
+to_string Square                 = "square"
+to_string Static                 = "static"
+to_string StatusBar              = "status-bar"
+to_string Sub                    = "sub"
+to_string Super                  = "super"
+to_string SwResize               = "sw-resize"
+to_string Table                  = "table"
+to_string TableCaption           = "table-caption"
+to_string TableCell              = "table-cell"
+to_string TableColumn            = "table-column"
+to_string TableColumnGroup       = "table-column-group"
+to_string TableFooterGroup       = "table-footer-group"
+to_string TableHeaderGroup       = "table-header-group"
+to_string TableRow               = "table-row"
+to_string TableRowGroup          = "table-row-group"
+to_string Teal                   = "teal"
+to_string Text                   = "text"
+to_string TextBottom             = "text-bottom"
+to_string TextTop                = "text-top"
+to_string Thick                  = "thick"
+to_string Thin                   = "thin"
+to_string Top                    = "top"
+to_string Transparent            = "transparent"
+to_string (URI a)                = "uri('" ++ a ++ "')"
+to_string Underline              = "underline"
+to_string UpperAlpha             = "upper-alpha"
+to_string UpperLatin             = "upper-latin"
+to_string UpperRoman             = "upper-roman"
+to_string Uppercase              = "uppercase"
+to_string Visible                = "visible"
+to_string WResize                = "w-resize"
+to_string Wait                   = "wait"
+to_string Weight100              = "weight100"
+to_string Weight200              = "weight200"
+to_string Weight300              = "weight300"
+to_string Weight400              = "weight400"
+to_string Weight500              = "weight500"
+to_string Weight600              = "weight600"
+to_string Weight700              = "weight700"
+to_string Weight800              = "weight800"
+to_string Weight900              = "weight900"
+to_string White                  = "white"
+to_string XLarge                 = "x-large"
+to_string XSmall                 = "x-small"
+to_string XXLarge                = "x-x-large"
+to_string XXSmall                = "x-x-small"
+to_string Yellow                 = "yellow"
+to_string Zero                   = "0"
+


### PR DESCRIPTION
**Note:** This branch accompanies the proposed _css_ branch in blaze-markup. For now, you'll have to clone both repositories and merge the `src/` directories if you want to test any of this. In other words, `cabal build` won't work unless the sources in my _css_ branch of blaze-markup are in the `src/` directory. But see the postscript below.

Along with some [slightly related] speed improvements, I proposed some minor changes in the conceptual model of an HTML element. I believe that all of these changes belong in either the blaze-html package or even in a separate blaze-css package altogether. Ideally, a Blaze syntax for CSS styles and classes would be part of a transformer stack on top of HTML and Markup layers. Maybe I'm just not good enough at this, but I really couldn't pull it off. I had to modify Internal.hs to get what I wanted.

An aside: In my humble opinion, the abstract model of elements in an HTML document would treat CSS styles and classes as equal in stature to HMTL attributes. The fact that both are transmitted as attribute values doesn't change the actual model. In practical terms, in an HTML document, a `font-family` might have been implemented as an attribute if something CSS-ish had been rolled into the HTML standard at the beginning.

The problem: I found myself loathing the

    H.td ! A.style (compose_style_value $ the_font : [borderLeftStyle Solid, backgroundColor Silver])

that covered my sugary Blaze code like a rash. Yes, I know what a stylesheet is, but there is still a reason for the style attribute. Abusing `A.class_` was prettier only by a small margin, and the stylesheet has to react to every whim found in the Haskell code.  The root problem is that attribute value builders for `style` and `class` attributes are painful and ugly. I tried in vain to roll my own operators that worked well with `(!)` until I decided to just promote styles and classes to the same rank as attribute.

Now I get to write like this:

    H.div ! S.position Absolute ! S.borderStyle Solid ! S.borderColor Black $
        H.span ! A.id "the-span" ! bold ! italic ! H.cssClass "class"

I understand that adding CSS functionality is a departure from the initial goal of producing _markup_ with as little overhead as possible. But if the goal includes syntactic beauty, ease of use _and_ raw speed - I think this has all of the above.

There's still work to do on non-String builders for Value. And I'd like to work on a MarkupM placeholder like `someAttributes` in the code below so I can write code like:

    the_attrs = someAttributes ! A.attr "value" ! S.fontFamily Serif !  H.cssClass "classy"

    the_div = H.div ! A.id "the-div" ! the_attrs $ "The DIV"

Lastly, maybe someone could eventually work this CSS stuff into the BlazeFromHtml code. Probably not me.

<br>

P.S. For the authors: I'll set up a working copy of all the sources in blaze-builder, blaze-markup and blaze-html in a single repository to make it easier to see all of this together. I'm sure you have this already. But unless you're using a GIT_DIR trick or something to divide it all into multiple packages, it may be extra work for you to pull my work from multiple repositories. I'll put it at [mikehat/blaze-all][blaze-all].
