### PR TITLE
Adds <u> parent tag to HTML5.

### DIFF
--- a/src/Util/GenerateHtmlCombinators.hs
+++ b/src/Util/GenerateHtmlCombinators.hs
@@ -412,7 +412,7 @@ html5 = HtmlVariant
         , "pre", "progress", "q", "rp", "rt", "ruby", "samp", "script"
         , "section", "select", "small", "span", "strong", "style", "sub"
         , "summary", "sup", "table", "tbody", "td", "textarea", "tfoot", "th"
-        , "thead", "time", "title", "tr", "ul", "var", "video"
+        , "thead", "time", "title", "tr", "u", "ul", "var", "video"
         ]
     , leafs =
         -- http://www.whatwg.org/specs/web-apps/current-work/multipage/syntax.html#void-elements

--- a/tests/Text/Blaze/Html/Tests.hs
+++ b/tests/Text/Blaze/Html/Tests.hs
@@ -57,6 +57,8 @@ tests = concatMap (uncurry makeTests) $ zip names
 
     , HtmlTest "<img src=\"&amp;\">" $ img ! src "&"
 
+    , HtmlTest "<u>hello</u>" $ H.u "hello"
+
     -- Pre-escaping cases
     , HtmlTest "<3 Haskell" $ preEscapedToMarkup ("<3 Haskell" :: String)
 


### PR DESCRIPTION
Hello!

First, thanks for this awesome library!

I was using it for HTML 5, and I noticed it does not have the underline tag `<u></u>` for HTML 5. This PR simply adds it to the generated code.

Cheers.