### PR TITLE
blaze-html.cabal: allow QuickCheck-2.10 and HUnit-1.6

### DIFF
--- a/blaze-html.cabal
+++ b/blaze-html.cabal
@@ -69,8 +69,8 @@ Test-suite blaze-html-tests
     Util.Tests
 
   Build-depends:
-    HUnit                      >= 1.2 && < 1.6,
-    QuickCheck                 >= 2.4 && < 2.10,
+    HUnit                      >= 1.2 && < 1.7,
+    QuickCheck                 >= 2.4 && < 2.11,
     containers                 >= 0.3 && < 0.6,
     test-framework             >= 0.4 && < 0.9,
     test-framework-hunit       >= 0.3 && < 0.4,


### PR DESCRIPTION
Signed-off-by: Sergei Trofimovich <slyfox@gentoo.org>