### PR TITLE
Allow bytestring-0.11

### DIFF
--- a/blaze-html.cabal
+++ b/blaze-html.cabal
@@ -57,7 +57,7 @@ Library
     base          >= 4    && < 5,
     blaze-builder >= 0.3  && < 0.5,
     blaze-markup  >= 0.8  && < 0.9,
-    bytestring    >= 0.9  && < 0.11,
+    bytestring    >= 0.9  && < 0.12,
     text          >= 0.10 && < 1.3
 
 Test-suite blaze-html-tests
@@ -89,7 +89,7 @@ Test-suite blaze-html-tests
     base          >= 4    && < 5,
     blaze-builder >= 0.3  && < 0.5,
     blaze-markup  >= 0.8  && < 0.9,
-    bytestring    >= 0.9  && < 0.11,
+    bytestring    >= 0.9  && < 0.12,
     text          >= 0.10 && < 1.3
 
 Source-repository head


### PR DESCRIPTION
Tested with 
```cabal
packages: .
tests: true

constraints:
  bytestring >= 0.11

source-repository-package
  type: git
  location: https://github.com/haskell/text
  tag: v1.2.4.1-rc1

source-repository-package
  type: git
  location: https://github.com/Bodigrim/blaze-builder

allow-newer:
  regex-base:bytestring,
  regex-posix:bytestring,
  blaze-markup:bytestring
```