### PR TITLE
Allow text 2.0, QuickCheck 2.14

### DIFF
--- a/blaze-html.cabal
+++ b/blaze-html.cabal
@@ -19,7 +19,7 @@ Build-type:    Simple
 Cabal-version: >= 1.8
 Tested-with:   GHC == 7.8.4, GHC == 7.10.3,
                GHC == 8.0.2, GHC == 8.2.2, GHC == 8.4.1,
-               GHC == 8.6.3, GHC == 8.8.1
+               GHC == 8.6.3, GHC == 8.8.1, GHC == 9.2.1
 
 Extra-source-files:
   CHANGELOG
@@ -58,7 +58,7 @@ Library
     blaze-builder >= 0.3  && < 0.5,
     blaze-markup  >= 0.8  && < 0.9,
     bytestring    >= 0.9  && < 0.12,
-    text          >= 0.10 && < 1.3
+    text          >= 0.10 && < 2.1
 
 Test-suite blaze-html-tests
   Type:           exitcode-stdio-1.0
@@ -80,7 +80,7 @@ Test-suite blaze-html-tests
 
   Build-depends:
     HUnit                      >= 1.2 && < 1.7,
-    QuickCheck                 >= 2.4 && < 2.14,
+    QuickCheck                 >= 2.4 && < 2.15,
     containers                 >= 0.3 && < 0.7,
     test-framework             >= 0.4 && < 0.9,
     test-framework-hunit       >= 0.3 && < 0.4,
@@ -90,7 +90,7 @@ Test-suite blaze-html-tests
     blaze-builder >= 0.3  && < 0.5,
     blaze-markup  >= 0.8  && < 0.9,
     bytestring    >= 0.9  && < 0.12,
-    text          >= 0.10 && < 1.3
+    text          >= 0.10 && < 2.1
 
 Source-repository head
   Type:     git


### PR DESCRIPTION
Tested with

    cabal test --constraint='text>=2' --constraint='QuickCheck>=2.14' -w ghc-9.2.1