### PR TITLE
Benchmarks cleanup and docs fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,6 @@ GHC = ghc
 GHCI = ghci
 GHC_FLAGS = -O2 -fforce-recomp -idoc/examples -ibenchmarks -isrc -itests
 
-BENCHMARK_FLAGS = --resamples 10000
-
 ################################################################################
 # Code generation
 ################################################################################
@@ -40,23 +38,13 @@ test-hpc:
 # Benchmarks
 ################################################################################
 
-benchmark:
-	$(GHC) $(GHC_FLAGS) --make -main-is RunHtmlBenchmarks benchmarks/RunHtmlBenchmarks.hs
-	./benchmarks/RunHtmlBenchmarks $(BENCHMARK_FLAGS) -u results.csv
-
 benchmark-server:
 	$(GHC) $(GHC_FLAGS) --make -threaded -main-is BenchmarkServer doc/examples/BenchmarkServer.lhs
 
 snap-benchmark-server:
 	$(GHC) $(GHC_FLAGS) --make -threaded -main-is SnapBenchmarkServer doc/examples/SnapBenchmarkServer.lhs
 
-benchmark-bigtable-non-haskell:
-	ruby benchmarks/bigtable/erb.rb
-	ruby benchmarks/bigtable/erubis.rb
-	php -n benchmarks/bigtable/php.php
-
 # Cleanup
 clean:
 	rm -rf doc/examples/BenchmarkServer
-	rm -rf benchmarks/HtmlBenchmarks
 	find . -name '*.o' -o -name '*.hi' | xargs rm

--- a/README.markdown
+++ b/README.markdown
@@ -26,10 +26,6 @@ Run the tests using
 
     make test
 
-And the benchmarks using
-
-    make benchmark
-
 blaze-from-html
 ---------------
 

--- a/website/benchmarks.markdown
+++ b/website/benchmarks.markdown
@@ -41,20 +41,20 @@ don't want some content to be escaped.
 
 # Running the benchmarks yourself
 
-Get the BlazeHtml repo.
+Get the `blaze-markup` repo.
 
-    git clone git://github.com/jaspervdj/blaze-html.git
-    cd blaze-html
+    git clone git://github.com/jaspervdj/blaze-markup.git
+    cd blaze-markup
 
 Run the ruby/php/... benchmarks. This requires you to have the different
 templating systems installed, of course.
 
-    make bench-bigtable-non-haskell
+    make benchmark-bigtable-non-haskell
 
 Run the BlazeHtml HTML benchmarks. The benchmark discussed above is called
 `bigTable`.
 
-    make bench-html
+    make benchmark
 
 The python benchmarks are located in the [spitfire] repository. Check out the
 code first:


### PR DESCRIPTION
I wanted to run benchmarks, but I discovered that the website's instructions were out of date.

Companion pull request in `blaze-markup`: <https://github.com/jaspervdj/blaze-markup/pull/66>