### PR TITLE
Add src/Util/GenerateHtmlCombinators/Html5.hs to extra-source-files

### DIFF
--- a/blaze-html.cabal
+++ b/blaze-html.cabal
@@ -35,6 +35,7 @@ Extra-source-files:
   CHANGELOG
   src/Util/Sanitize.hs
   src/Util/GenerateHtmlCombinators.hs
+  src/Util/GenerateHtmlCombinators/Html5.hs
 
 Library
   Hs-source-dirs:   src


### PR DESCRIPTION
The file is new and not distributed in the source distribution. It's essential to make src/Util/GenerateHtmlCombinators.hs usable.